### PR TITLE
configure memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,8 +129,7 @@ ENV CANTALOUPE_CONFIGS=$CANTALOUPE_CONFIGS
 ENV CANTALOUPE_PROPERTIES=${CANTALOUPE_CONFIGS}/actual_cantaloupe.properties
 ARG GEM_PATH
 ENV GEM_PATH=$GEM_PATH
-ENV CANTALOUPE_MEM=1g
-ENV JAVA_OPTS="-Xms${CANTALOUPE_MEM} -Xmx${CANTALOUPE_MEM} -server -Djava.awt.headless=true -Dcantaloupe.config=${CANTALOUPE_PROPERTIES}"
+ENV CANTALOUPE_MEM="1g"
 ARG CANTALOUPE_UID
 ARG CANTALOUPE_GID
 
@@ -174,7 +173,7 @@ WORKDIR /cantaloupe
 COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID --from=cantaloupe-build /build/cantaloupe/target/cantaloupe-${CANTALOUPE_VERSION}.jar cantaloupe.jar
 COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID --chmod=500 <<-'EOS' entrypoint.sh
 #!/bin/bash
-exec java $JAVA_OPTS -jar cantaloupe.jar
+exec java -Xms${CANTALOUPE_MEM} -Xmx${CANTALOUPE_MEM} -server -Djava.awt.headless=true -Dcantaloupe.config=${CANTALOUPE_PROPERTIES} -jar cantaloupe.jar
 
 EOS
 


### PR DESCRIPTION
Simplifies memory configuration by allowing it to be set as it's own env var


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated how Java memory settings are configured for the Cantaloupe application in the container, simplifying environment variables and JVM option handling. No user-facing changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->