### PR TITLE
SEC-1601: Java memory percentage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,6 @@ ENV CANTALOUPE_PROPERTIES=${CANTALOUPE_CONFIGS}/actual_cantaloupe.properties
 ARG GEM_PATH
 ENV GEM_PATH=$GEM_PATH
 ENV CANTALOUPE_MEM=1g
-ENV JAVA_OPTS="-Xms${CANTALOUPE_MEM} -Xmx${CANTALOUPE_MEM} -server -Djava.awt.headless=true -Dcantaloupe.config=${CANTALOUPE_PROPERTIES}"
 ARG CANTALOUPE_UID
 ARG CANTALOUPE_GID
 
@@ -167,12 +166,16 @@ COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID actual_cantaloupe.properties
 WORKDIR /var/cache/cantaloupe
 WORKDIR /var/log/cantaloupe
 
+WORKDIR /jmx
+ADD --link --chmod=644 https://github.com/prometheus/jmx_exporter/releases/download/1.4.0/jmx_prometheus_javaagent-1.4.0.jar jmx_prometheus_javaagent.jar
+COPY --chmod=644 jmx.yml ./
+
 # Get and unpack Cantaloupe release archive
 WORKDIR /cantaloupe
 COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID --from=cantaloupe-build /build/cantaloupe/target/cantaloupe-${CANTALOUPE_VERSION}.jar cantaloupe.jar
 COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID --chmod=500 <<-'EOS' entrypoint.sh
 #!/bin/bash
-exec java $JAVA_OPTS -jar cantaloupe.jar
+exec java -Xms${CANTALOUPE_MEM} -Xmx${CANTALOUPE_MEM} -javaagent:/jmx/jmx_prometheus_javaagent.jar=3001:/jmx/jmx.yml -server -Djava.awt.headless=true -Dcantaloupe.config=${CANTALOUPE_PROPERTIES} -jar cantaloupe.jar
 
 EOS
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,10 +166,15 @@ COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID actual_cantaloupe.properties
 WORKDIR /var/cache/cantaloupe
 WORKDIR /var/log/cantaloupe
 
-# renovate: datasource=github-releases depName=prometheus/jmx_exporter
-ARG JMX_EXRPORTER_VERSION=1.4.0
+# renovate: datasource=github-release-attachments depName=prometheus/jmx_exporter
+ARG JMX_EXPORTER_VERSION=1.4.0
+ARG JMX_EXPORTER_DIGEST=sha256:db1492e95a7ee95cd5e0a969875c0d4f0ef6413148d750351a41cc71d775f59a
 WORKDIR /jmx
-ADD --link --chmod=644 https://github.com/prometheus/jmx_exporter/releases/download/$JMX_EXRPORTER_VERSION/jmx_prometheus_javaagent-$JMX_EXRPORTER_VERSION.jar jmx_prometheus_javaagent.jar
+ADD \
+  --link \
+  --chmod=644 \
+  --checksum=$JMX_EXPORTER_DIGEST \
+  https://github.com/prometheus/jmx_exporter/releases/download/$JMX_EXPORTER_VERSION/jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.jar jmx_prometheus_javaagent.jar
 COPY --chmod=644 jmx.yml ./
 
 # Get and unpack Cantaloupe release archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ ENV CANTALOUPE_CONFIGS=$CANTALOUPE_CONFIGS
 ENV CANTALOUPE_PROPERTIES=${CANTALOUPE_CONFIGS}/actual_cantaloupe.properties
 ARG GEM_PATH
 ENV GEM_PATH=$GEM_PATH
-ENV CANTALOUPE_MEM=1g
+ENV JAVA_MEMORY="-Xms1g -Xmx1g"
 ARG CANTALOUPE_UID
 ARG CANTALOUPE_GID
 
@@ -175,7 +175,7 @@ WORKDIR /cantaloupe
 COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID --from=cantaloupe-build /build/cantaloupe/target/cantaloupe-${CANTALOUPE_VERSION}.jar cantaloupe.jar
 COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID --chmod=500 <<-'EOS' entrypoint.sh
 #!/bin/bash
-exec java -Xms${CANTALOUPE_MEM} -Xmx${CANTALOUPE_MEM} -javaagent:/jmx/jmx_prometheus_javaagent.jar=3001:/jmx/jmx.yml -server -Djava.awt.headless=true -Dcantaloupe.config=${CANTALOUPE_PROPERTIES} -jar cantaloupe.jar
+exec java $JAVA_MEMORY -javaagent:/jmx/jmx_prometheus_javaagent.jar=3001:/jmx/jmx.yml -server -Djava.awt.headless=true -Dcantaloupe.config=${CANTALOUPE_PROPERTIES} -jar cantaloupe.jar
 
 EOS
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,8 +166,10 @@ COPY --link --chown=$CANTALOUPE_UID:$CANTALOUPE_GID actual_cantaloupe.properties
 WORKDIR /var/cache/cantaloupe
 WORKDIR /var/log/cantaloupe
 
+# renovate: datasource=github-releases depName=prometheus/jmx_exporter
+ARG JMX_EXRPORTER_VERSION=1.4.0
 WORKDIR /jmx
-ADD --link --chmod=644 https://github.com/prometheus/jmx_exporter/releases/download/1.4.0/jmx_prometheus_javaagent-1.4.0.jar jmx_prometheus_javaagent.jar
+ADD --link --chmod=644 https://github.com/prometheus/jmx_exporter/releases/download/$JMX_EXRPORTER_VERSION/jmx_prometheus_javaagent-$JMX_EXRPORTER_VERSION.jar jmx_prometheus_javaagent.jar
 COPY --chmod=644 jmx.yml ./
 
 # Get and unpack Cantaloupe release archive

--- a/jmx.yml
+++ b/jmx.yml
@@ -1,0 +1,2 @@
+rules:
+- pattern: ".*"


### PR DESCRIPTION
- Makes the java memory settings completely customizable from environment variables.
- Adds in the jmx exporter to allow monitoring of jvm memory usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Built-in Prometheus JMX exporter enabled; metrics exposed on port 3001 with a default catch‑all configuration.

- Chores
  - Simplified Java memory configuration via a single JAVA_MEMORY setting (-Xms1g -Xmx1g).
  - Startup now attaches the JMX agent and uses standard JVM flags for consistent runtime behavior.
  - Image includes the JMX exporter and its default configuration for out‑of‑the‑box monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->